### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/selemondev/project-guardian-cli/security/code-scanning/3](https://github.com/selemondev/project-guardian-cli/security/code-scanning/3)

The best way to fix the problem is to add an explicit `permissions` key at the top level of the workflow (just below the `name` field or the `on` field), specifying the minimal permissions required for the jobs to run. In this case, both jobs (lint and test) only require read access to contents, so setting `permissions: contents: read` at the root will apply to all jobs and aligns with least privilege. To implement, add the following block of code:

```yaml
permissions:
  contents: read
```

This should be placed just below the `name: CI` and before the `on:` block (or just after `on:` if desired).

No new methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
