### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/selemondev/project-guardian-cli/security/code-scanning/1](https://github.com/selemondev/project-guardian-cli/security/code-scanning/1)

To fix the problem, add an explicit `permissions` setting to the workflow to restrict the default permissions granted to the GITHUB_TOKEN. The most secure approach is to start with the minimum and only grant write access to the specific scopes required by the steps in the job. In this case, the workflow checks out code, sets up Node.js, updates the changelog (which may create a GitHub release or manage PRs), and publishes to npm (which uses a separate npm token). The default recommendation is `contents: read`, but if the changelog/PR step or any publishing requires writing GitHub releases or pull requests, you may need to grant `contents: write` and `pull-requests: write`. As a minimal, safe starting point complying with the recommendation, add `permissions: contents: read` at the workflow root (before `jobs:`), so all jobs default to read-only.

**What to change:**  
- In .github/workflows/release.yml, add the block:
  ```yaml
  permissions:
    contents: read
  ```
  after the `name:` and before `on:` (i.e., before the jobs declaration).
- No further changes to methods, imports, or logic are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
